### PR TITLE
Kill command checking

### DIFF
--- a/Helium.js
+++ b/Helium.js
@@ -55,23 +55,21 @@ bot.on("message", function(user, userID, channelID, message, rawEvent) {
     
 // Kill
     
-    if(message === "!kill") {
-        if(userID == "138862213527109632") {
+    if(message === "!kill" && userID == "138862213527109632") {
             sendMessages(channelID, ["**-= Shutting down, Bye! =-**"]);
             setTimeout(function(){ console.log("\n\n\n[INFO] Kill command has been triggered!\n\n") }, 2000);
             setTimeout(function(){ process.exit(0) }, 4000);
-        } 
-        else {
+    } 
+    else {
         sendMessages(channelID, [":x: || Only Zacimac can perform this command || :x:"]);
-        }
-        }
+    }
     
     if (message === "!kill -n" && userID == "138862213527109632") {
         console.log("\n\n\n[INFO] Kill command has been triggered!\n\n")
         setTimeout(function(){ process.exit(0) }, 2000);
     }
-    else if (message === "!kill -n"){
-    sendMessages(channelID, [":x: || Only Zacimac can perform this command || :x:"]);
+    else {
+    	sendMessages(channelID, [":x: || Only Zacimac can perform this command || :x:"]);
     } 
     
 // info


### PR DESCRIPTION
When checking the kill command, if you check that the command is "`!kill`" AND if the `userID` is zacimac's then perform the subsequent code. Otherwise, if one of the checks fails, the statement will drop into the else block, thus letting the user know they cannot use this command. Personally, you should let it silently fail by taking out the "`else{...}`" altogether.